### PR TITLE
Remove tortoise. prefix from imports

### DIFF
--- a/scripts/tortoise_tts.py
+++ b/scripts/tortoise_tts.py
@@ -9,9 +9,9 @@ import time
 import torch
 import torchaudio
 
-from tortoise.api import MODELS_DIR, TextToSpeech
-from tortoise.utils.audio import get_voices, load_voices, load_audio
-from tortoise.utils.text import split_and_recombine_text
+from api import MODELS_DIR, TextToSpeech
+from utils.audio import get_voices, load_voices, load_audio
+from utils.text import split_and_recombine_text
 
 parser = argparse.ArgumentParser(
     description='TorToiSe is a text-to-speech program that is capable of synthesizing speech '

--- a/tortoise/api.py
+++ b/tortoise/api.py
@@ -9,19 +9,19 @@ import torch.nn.functional as F
 import progressbar
 import torchaudio
 
-from tortoise.models.classifier import AudioMiniEncoderWithClassifierHead
-from tortoise.models.diffusion_decoder import DiffusionTts
-from tortoise.models.autoregressive import UnifiedVoice
+from models.classifier import AudioMiniEncoderWithClassifierHead
+from models.diffusion_decoder import DiffusionTts
+from models.autoregressive import UnifiedVoice
 from tqdm import tqdm
-from tortoise.models.arch_util import TorchMelSpectrogram
-from tortoise.models.clvp import CLVP
-from tortoise.models.cvvp import CVVP
-from tortoise.models.random_latent_generator import RandomLatentConverter
-from tortoise.models.vocoder import UnivNetGenerator
-from tortoise.utils.audio import wav_to_univnet_mel, denormalize_tacotron_mel, TacotronSTFT
-from tortoise.utils.diffusion import SpacedDiffusion, space_timesteps, get_named_beta_schedule
-from tortoise.utils.tokenizer import VoiceBpeTokenizer
-from tortoise.utils.wav2vec_alignment import Wav2VecAlignment
+from models.arch_util import TorchMelSpectrogram
+from models.clvp import CLVP
+from models.cvvp import CVVP
+from models.random_latent_generator import RandomLatentConverter
+from models.vocoder import UnivNetGenerator
+from utils.audio import wav_to_univnet_mel, denormalize_tacotron_mel, TacotronSTFT
+from utils.diffusion import SpacedDiffusion, space_timesteps, get_named_beta_schedule
+from utils.tokenizer import VoiceBpeTokenizer
+from utils.wav2vec_alignment import Wav2VecAlignment
 from contextlib import contextmanager
 from huggingface_hub import hf_hub_download
 pbar = None

--- a/tortoise/api_fast.py
+++ b/tortoise/api_fast.py
@@ -9,22 +9,22 @@ import torch.nn.functional as F
 import progressbar
 import torchaudio
 import numpy as np
-from tortoise.models.classifier import AudioMiniEncoderWithClassifierHead
-from tortoise.models.diffusion_decoder import DiffusionTts
-from tortoise.models.autoregressive import UnifiedVoice
+from models.classifier import AudioMiniEncoderWithClassifierHead
+from models.diffusion_decoder import DiffusionTts
+from models.autoregressive import UnifiedVoice
 from tqdm import tqdm
-from tortoise.models.arch_util import TorchMelSpectrogram
-from tortoise.models.clvp import CLVP
-from tortoise.models.cvvp import CVVP
-from tortoise.models.hifigan_decoder import HifiganGenerator
-from tortoise.models.random_latent_generator import RandomLatentConverter
-from tortoise.models.vocoder import UnivNetGenerator
-from tortoise.utils.audio import wav_to_univnet_mel, denormalize_tacotron_mel
-from tortoise.utils.diffusion import SpacedDiffusion, space_timesteps, get_named_beta_schedule
-from tortoise.utils.tokenizer import VoiceBpeTokenizer
-from tortoise.utils.wav2vec_alignment import Wav2VecAlignment
+from models.arch_util import TorchMelSpectrogram
+from models.clvp import CLVP
+from models.cvvp import CVVP
+from models.hifigan_decoder import HifiganGenerator
+from models.random_latent_generator import RandomLatentConverter
+from models.vocoder import UnivNetGenerator
+from utils.audio import wav_to_univnet_mel, denormalize_tacotron_mel
+from utils.diffusion import SpacedDiffusion, space_timesteps, get_named_beta_schedule
+from utils.tokenizer import VoiceBpeTokenizer
+from utils.wav2vec_alignment import Wav2VecAlignment
 from contextlib import contextmanager
-from tortoise.models.stream_generator import init_stream_support
+from models.stream_generator import init_stream_support
 from huggingface_hub import hf_hub_download
 pbar = None
 init_stream_support()

--- a/tortoise/eval.py
+++ b/tortoise/eval.py
@@ -4,7 +4,7 @@ import os
 import torchaudio
 
 from api import TextToSpeech
-from tortoise.utils.audio import load_audio
+from utils.audio import load_audio
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()

--- a/tortoise/get_conditioning_latents.py
+++ b/tortoise/get_conditioning_latents.py
@@ -3,7 +3,7 @@ import os
 import torch
 
 from api import TextToSpeech
-from tortoise.utils.audio import load_audio, get_voices
+from utils.audio import load_audio, get_voices
 
 """
 Dumps the conditioning latents for the specified voice to disk. These are expressive latents which can be used for

--- a/tortoise/is_this_from_tortoise.py
+++ b/tortoise/is_this_from_tortoise.py
@@ -1,7 +1,7 @@
 import argparse
 
 from api import classify_audio_clip
-from tortoise.utils.audio import load_audio
+from utils.audio import load_audio
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()

--- a/tortoise/models/arch_util.py
+++ b/tortoise/models/arch_util.py
@@ -6,7 +6,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import torchaudio
-from tortoise.models.xtransformers import ContinuousTransformerWrapper, RelativePositionBias
+from models.xtransformers import ContinuousTransformerWrapper, RelativePositionBias
 
 
 def zero_module(module):

--- a/tortoise/models/autoregressive.py
+++ b/tortoise/models/autoregressive.py
@@ -6,8 +6,8 @@ import torch.nn.functional as F
 from transformers import GPT2Config, GPT2PreTrainedModel, LogitsProcessorList
 from transformers.modeling_outputs import CausalLMOutputWithCrossAttentions
 from transformers.utils.model_parallel_utils import get_device_map, assert_device_map
-from tortoise.models.arch_util import AttentionBlock
-from tortoise.utils.typical_sampling import TypicalLogitsWarper
+from models.arch_util import AttentionBlock
+from utils.typical_sampling import TypicalLogitsWarper
 
 
 def null_position_embeddings(range, dim):

--- a/tortoise/models/classifier.py
+++ b/tortoise/models/classifier.py
@@ -1,7 +1,7 @@
 import torch
 import torch.nn as nn
 
-from tortoise.models.arch_util import Upsample, Downsample, normalization, zero_module, AttentionBlock
+from models.arch_util import Upsample, Downsample, normalization, zero_module, AttentionBlock
 
 
 class ResBlock(nn.Module):

--- a/tortoise/models/clvp.py
+++ b/tortoise/models/clvp.py
@@ -3,9 +3,9 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch import einsum
 
-from tortoise.models.arch_util import CheckpointedXTransformerEncoder
-from tortoise.models.transformer import Transformer
-from tortoise.models.xtransformers import Encoder
+from models.arch_util import CheckpointedXTransformerEncoder
+from models.transformer import Transformer
+from models.xtransformers import Encoder
 
 
 def exists(val):

--- a/tortoise/models/cvvp.py
+++ b/tortoise/models/cvvp.py
@@ -3,8 +3,8 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch import einsum
 
-from tortoise.models.arch_util import AttentionBlock
-from tortoise.models.xtransformers import ContinuousTransformerWrapper, Encoder
+from models.arch_util import AttentionBlock
+from models.xtransformers import ContinuousTransformerWrapper, Encoder
 
 
 def exists(val):

--- a/tortoise/models/diffusion_decoder.py
+++ b/tortoise/models/diffusion_decoder.py
@@ -7,7 +7,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch import autocast
 
-from tortoise.models.arch_util import normalization, AttentionBlock
+from models.arch_util import normalization, AttentionBlock
 
 
 def is_latent(t):

--- a/tortoise/socket_server.py
+++ b/tortoise/socket_server.py
@@ -1,7 +1,7 @@
 import spacy
 import threading
 import socket
-from tortoise.api_fast import TextToSpeech
+from api_fast import TextToSpeech
 from utils.audio import load_voices
 
 tts = TextToSpeech()

--- a/tortoise/utils/audio.py
+++ b/tortoise/utils/audio.py
@@ -7,7 +7,7 @@ import torchaudio
 import numpy as np
 from scipy.io.wavfile import read
 
-from tortoise.utils.stft import STFT
+from utils.stft import STFT
 
 
 BUILTIN_VOICES_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../voices')

--- a/tortoise/utils/wav2vec_alignment.py
+++ b/tortoise/utils/wav2vec_alignment.py
@@ -4,7 +4,7 @@ import torch
 import torchaudio
 from transformers import Wav2Vec2ForCTC, Wav2Vec2FeatureExtractor, Wav2Vec2CTCTokenizer, Wav2Vec2Processor
 
-from tortoise.utils.audio import load_audio
+from utils.audio import load_audio
 
 
 def max_alignment(s1, s2, skip_character='~', record=None):


### PR DESCRIPTION
## Summary
- drop `tortoise.` package prefix in all python imports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687088f651488325a4a846a2eed423d1